### PR TITLE
Agent: Support TCP Tunnels

### DIFF
--- a/not_my_board/_http.py
+++ b/not_my_board/_http.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python3
 
-import asyncio
+import contextlib
 import json
 import urllib.parse
 
 import h11
+
+import not_my_board._util as util
 
 
 class ProtocolError(Exception):
@@ -26,35 +28,72 @@ async def get_json(url):
     )
 
     if url.scheme == "https":
-        reader, writer = await asyncio.open_connection(
-            url.hostname, url.port or 443, ssl=True
-        )
+        default_port = 443
+        ssl = True
     elif url.scheme == "http":
-        reader, writer = await asyncio.open_connection(url.hostname, url.port or 80)
+        default_port = 80
+        ssl = False
     else:
         raise ValueError("Unknown scheme '{url.scheme}'")
 
-    writer.write(to_send)
-    writer.write(conn.send(h11.EndOfMessage()))
-    await writer.drain()
+    port = url.port or default_port
 
-    async def receive_all():
+    async with util.connect(url.hostname, port, ssl=ssl) as (reader, writer):
+        writer.write(to_send)
+        writer.write(conn.send(h11.EndOfMessage()))
+        await writer.drain()
+
+        async def receive_all():
+            while True:
+                event = conn.next_event()
+                if event is h11.NEED_DATA:
+                    conn.receive_data(await reader.read(4096))
+                elif isinstance(event, h11.Response):
+                    if event.status_code != 200:
+                        raise ProtocolError(
+                            f"Expected status code 200, got {event.status_code}"
+                        )
+                elif isinstance(event, h11.Data):
+                    yield event.data
+                elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
+                    break
+
+        content = b"".join([data async for data in receive_all()])
+
+    return json.loads(content)
+
+
+@contextlib.asynccontextmanager
+async def open_tunnel(proxy_host, proxy_port, target_host, target_port):
+    headers = [
+        ("Host", f"{target_host}:{target_port}"),
+        ("User-Agent", h11.PRODUCT_ID),
+    ]
+
+    conn = h11.Connection(our_role=h11.CLIENT)
+    to_send = conn.send(
+        h11.Request(
+            method="CONNECT", target=f"{target_host}:{target_port}", headers=headers
+        )
+    )
+
+    async with util.connect(proxy_host, proxy_port) as (reader, writer):
+        writer.write(to_send)
+        writer.write(conn.send(h11.EndOfMessage()))
+        await writer.drain()
+
         while True:
             event = conn.next_event()
             if event is h11.NEED_DATA:
                 conn.receive_data(await reader.read(4096))
             elif isinstance(event, h11.Response):
-                if event.status_code != 200:
+                response = event
+                if response.status_code != 200:
                     raise ProtocolError(
                         f"Expected status code 200, got {event.status_code}"
                     )
-            elif isinstance(event, h11.Data):
-                yield event.data
-            elif isinstance(event, (h11.EndOfMessage, h11.PAUSED)):
+
+                yield reader, writer, conn.trailing_data[0]
                 break
-
-    content = b"".join([data async for data in receive_all()])
-    writer.close()
-    await writer.wait_closed()
-
-    return json.loads(content)
+            else:
+                raise ProtocolError(f"Unexpected event: {event}")

--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -45,7 +45,6 @@ class UsbIpDevice:
         self._refresh_event = asyncio.Event()
         self._is_exported = False
 
-    @util.connection_handler
     async def handle_client(self, reader, writer):
         await _UsbIpConnection(self, reader, writer).handle_client()
 
@@ -501,7 +500,7 @@ async def _main():
             await attach(reader, writer, args.busid, args.vhci_port)
     else:
         device = UsbIpDevice(args.busid)
-        server = await asyncio.start_server(
+        server = util.Server(
             device.handle_client, port=args.port, family=socket.AF_INET
         )
         async with server:

--- a/not_my_board/_util/__init__.py
+++ b/not_my_board/_util/__init__.py
@@ -1,3 +1,15 @@
-from ._asyncio import connection_handler, run_concurrently
+from ._asyncio import (
+    Server,
+    UnixServer,
+    cancel_tasks,
+    connect,
+    relay_streams,
+    run_concurrently,
+)
 from ._matching import find_matching
 from ._misc import ws_connect
+
+try:
+    from tomllib import loads as toml_loads
+except ModuleNotFoundError:
+    from tomli import loads as toml_loads

--- a/not_my_board/_util/_asyncio.py
+++ b/not_my_board/_util/_asyncio.py
@@ -1,36 +1,105 @@
 import asyncio
-import functools
+import contextlib
 import traceback
+
+_RELAY_BUFFER_SIZE = 64 * 1024  # 64 KiB
 
 
 async def run_concurrently(*coros):
+    """Run coros concurrently and cancel others on error.
+
+    Like `asyncio.gather()`, but if one task raises an exception, all other
+    tasks are cancelled.
+    """
+
     tasks = [asyncio.create_task(coro) for coro in coros]
     try:
         return await asyncio.gather(*tasks)
     finally:
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-
-        for task in tasks:
-            if not task.done():
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+        await cancel_tasks(tasks)
 
 
-def connection_handler(func):
-    """Decorator for asyncio connection handlers
+async def cancel_tasks(tasks):
+    """Cancel tasks and wait until all are cancelled"""
 
-    Catches and logs every exception raised in the handler and closes the
-    connection, when the handler function returns.
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+
+    for task in tasks:
+        if not task.done():
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+
+@contextlib.asynccontextmanager
+async def connect(*args, **kwargs):
+    """Wraps `asyncio.open_connection()` in a context manager
+
+    The connection is closed when leaving the context.
     """
 
-    @functools.wraps(func)
-    async def wrapper(self, reader, writer):
+    reader, writer = await asyncio.open_connection(*args, **kwargs)
+    try:
+        yield reader, writer
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def relay_streams(client_r, client_w, remote_r, remote_w):
+    """Relay data between two streams"""
+
+    async def relay(reader, writer):
+        while True:
+            data = await reader.read(_RELAY_BUFFER_SIZE)
+            if not data:
+                writer.write_eof()
+                return
+
+            writer.write(data)
+            await writer.drain()
+
+    await run_concurrently(relay(client_r, remote_w), relay(remote_r, client_w))
+
+
+class Server:
+    """Wraps `asyncio.start_server()` and cleans up open connections
+
+    When leaving the context, not only are the listening sockets closed,
+    but all currently runnning connection handler callbacks are also
+    cancelled.
+
+    It also wrapps the connection handler to catch and log every exception
+    raised in the handler and also closes the connection, when the handler
+    function returns.
+    """
+
+    def __init__(self, connection_handler, *args, **kwargs):
+        self._connection_handler = connection_handler
+        self._args = args
+        self._kwargs = kwargs
+        self._tasks = set()
+
+    async def __aenter__(self):
+        self._server = await self._start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._server.close()
+        await self._server.wait_closed()
+        await cancel_tasks(self._tasks.copy())
+
+    def _on_connect(self, reader, writer):
+        task = asyncio.create_task(self._run_handler(reader, writer))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_handler(self, reader, writer):
         try:
-            await func(self, reader, writer)
+            await self._connection_handler(reader, writer)
         except Exception:
             traceback.print_exc()
         finally:
@@ -40,4 +109,17 @@ def connection_handler(func):
             except Exception:
                 pass
 
-    return wrapper
+    async def _start(self):
+        return await asyncio.start_server(self._on_connect, *self._args, **self._kwargs)
+
+    async def serve_forever(self):
+        await self._server.serve_forever()
+
+
+class UnixServer(Server):
+    """Same as `Server`, but for `asyncio.start_unix_server()`"""
+
+    async def _start(self):
+        return await asyncio.start_unix_server(
+            self._on_connect, *self._args, **self._kwargs
+        )

--- a/not_my_board/cli/__init__.py
+++ b/not_my_board/cli/__init__.py
@@ -11,11 +11,6 @@ from not_my_board._serve import serve
 
 from ..__about__ import __version__
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
-
 
 def main():
     logging.basicConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,6 @@ generated-members = [
     "websockets",
     "pydantic",
 ]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
When attaching a place with a tcp interface, then the agent listens on the specified "local_port". Every connection to that port is forwarded to the remote tcp server, by going through the exporter HTTP proxy.