### PR TITLE
Agent: Don't return reservations on shutdown

### DIFF
--- a/not_my_board/_agent.py
+++ b/not_my_board/_agent.py
@@ -67,10 +67,6 @@ class Agent:
             if place.is_attached:
                 await place.detach()
 
-        while self._reserved_places:
-            _, place = self._reserved_places.popitem()
-            await self._server_proxy.return_reservation(place.id)
-
     # TODO: hide from JSON-RPC interface
     async def serve_forever(self):
         await util.run_concurrently(


### PR DESCRIPTION
The server proxy isn't active anymore in the cleanup callback, so the return_reservation calls failed. Instead of trying to keep the server proxy alive, just rely on the server to free the reserved places, when the websocket connection closes.