### PR TITLE
USB/IP test: Fix race

### DIFF
--- a/tests/test_usbip.py
+++ b/tests/test_usbip.py
@@ -136,7 +136,7 @@ async def test_usb_forwarding(vms):
                 await vms.client.ssh("test -e /sys/bus/usb/devices/2-1")
                 try:
                     await vms.exporter.usb_detach()
-                    await vms.client.ssh("! test -e /sys/bus/usb/devices/2-1")
+                    await vms.client.ssh_poll("! test -e /sys/bus/usb/devices/2-1")
                 finally:
                     await vms.exporter.usb_attach()
 


### PR DESCRIPTION
The USB device takes a while to disappear in the client VM after the real device was detached from the exporter VM. This is only noticeable without KVM acceleration, i.e. on GitHub Actions.