### PR TITLE
Call shutdown_default_executor() conditionally

### DIFF
--- a/not_my_board/_util/_asyncio.py
+++ b/not_my_board/_util/_asyncio.py
@@ -22,7 +22,8 @@ def run(coro, debug=False):
 
         loop.run_until_complete(task)
         loop.run_until_complete(loop.shutdown_asyncgens())
-        loop.run_until_complete(loop.shutdown_default_executor())
+        if hasattr(loop, "shutdown_default_executor"):
+            loop.run_until_complete(loop.shutdown_default_executor())
     except asyncio.CancelledError:
         pass
     finally:


### PR DESCRIPTION
The function was only added in Python version 3.9.