### PR TITLE
Rename Server to Hub

### DIFF
--- a/doc/explanation/overview.md
+++ b/doc/explanation/overview.md
@@ -3,12 +3,12 @@
 A board farm set up with `not-my-board` consists of multiple components:
 
 - **Place**: The physical embedded hardware setup.
-- **Server**: A single instance, that schedules access to *Places*.
+- **Hub**: A single instance, that schedules access to *Places*.
 - **Exporter**: This runs on the host, where the *Place* is connected. It
-  registers the *Place* with the *Server*.
+  registers the *Place* with the *Hub*.
 - **Agent**: A board farm user runs this on their host. It requests a *Place*
-  from the *Server*, connects directly to the *Exporter* and tunnels resources
-  from the *Exporter* to the host of the user.
+  from the *Hub*, connects directly to the *Exporter* and tunnels resources from
+  the *Exporter* to the host of the user.
 - **Client**: The CLI, that controls the *Agent*.
 
 ## Place
@@ -19,22 +19,22 @@ controllable power supply, a wireless access point or a camera. Of course it's
 not even limited to a single board: It can be a system consisting of multiple
 connected boards. Every board or equipment is called a *Part*.
 
-## Server
+## Hub
 
-The *Server* provides its interface over HTTP(S) and WebSocket. *Exporter* and
+The *Hub* provides its interface over HTTP(S) and WebSocket. *Exporter* and
 *Agent* stay registered as long as the WebSocket connection is alive. If the
 *Exporter* connection breaks, then the *Place* will no longer be scheduled. If
 the *Agent* connection breaks, then the user loses access and the *Place* can be
 reserved by another user.
 
-The *Server* only provides a list of known *Places* with their description. The
-*Agent* then filters the list and asks the *Server* to reserve one of all the
-possible candidate *Places*. As soon as one of the candidates is free, the
-*Server* let's both *Exporter* and *Agent* know about the new reservation.
+The *Hub* only provides a list of known *Places* with their description. The
+*Agent* then filters the list and asks the *Hub* to reserve one of all the
+possible candidate *Places*. As soon as one of the candidates is free, the *Hub*
+let's both *Exporter* and *Agent* know about the new reservation.
 
 ## Exporter
 
-The *Exporter* opens a WebSocket connection to the *Server* and exports the
+The *Exporter* opens a WebSocket connection to the *Hub* and exports the
 resources as an HTTP proxy. By not exporting the ports directly, only the HTTP
 proxy port needs to be opened in the firewall and the *Exporter* can
 authenticate the user before granting access.
@@ -44,8 +44,8 @@ supply), or over USB/IP, like the USB port of the board or the USB to serial
 converter.
 
 The proxy uses IP-based authentication to avoid the TLS overhead. Once the
-*Place* of the *Exporter* is reserved, the *Server* tells the *Exporter* which
-IP address to allow access.
+*Place* of the *Exporter* is reserved, the *Hub* tells the *Exporter* which IP
+address to allow access.
 
 The exporter assigns specific tags to the exported parts of the place. Those
 tags describe to what the parts are compatible with. An *Agent* can then filter
@@ -54,17 +54,17 @@ based on those tags.
 ## Agent
 
 The *Agent* is a long running process on the host of the user, to keep the
-connection to the *Server* open and to tunnel the resources from the *Exporter*.
-It listens on a Unix domain socket for commands from the *Client*.
+connection to the *Hub* open and to tunnel the resources from the *Exporter*. It
+listens on a Unix domain socket for commands from the *Client*.
 
 The *Client* provides an import description of the *Place* it wants, i.e. which
 parts it needs (identified by the compatible tags) and where to attach those
 parts. For example: I need a "Raspberry Pi" and want its USB serial adapter
 attached to USB port `3-4` and its USB port to `3-5`. The *Agent* then filters
-all the exported *Places* based on that description and gives the *Server* a
-list of the matching candidates. As soon as the *Server* reserves one of the
-candidates, the *Agent* connects directly with the *Exporter* and attaches the
-resources as requested.
+all the exported *Places* based on that description and gives the *Hub* a list
+of the matching candidates. As soon as the *Hub* reserves one of the candidates,
+the *Agent* connects directly with the *Exporter* and attaches the resources as
+requested.
 
 ## Client
 

--- a/doc/reference/cli.md
+++ b/doc/reference/cli.md
@@ -4,14 +4,14 @@ Here's a description of all the commands and options `not-my-board` supports.
 
 ## Commands
 
-**`serve`** [**`-h`**|**`--help`**]
-: Start the board farm *Server*. There should be only one server in the entire
+**`hub`** [**`-h`**|**`--help`**]
+: Start the board farm *Hub*. There should be only one hub in the entire
   network.
 
-**`export`** [**`-h`**|**`--help`**] *server_url* *export_description*
+**`export`** [**`-h`**|**`--help`**] *hub_url* *export_description*
 : Make connected boards and equipment available in the board farm.
 
-**`agent`** [**`-h`**|**`--help`**] *server_url*
+**`agent`** [**`-h`**|**`--help`**] *hub_url*
 : Start an *Agent*.
 
 **`reserve`** [**`-h`**|**`--help`**] [**`-v`**|**`--verbose`**] [**`-n`**|**`--with-name`** *name*] *import_description*
@@ -47,8 +47,8 @@ Here's a description of all the commands and options `not-my-board` supports.
 Show help message and exit.
 ```
 
-```{option} server_url
-HTTP or HTTPS URL of the _Server_.
+```{option} hub_url
+HTTP or HTTPS URL of the *Hub*.
 ```
 
 ```{option} export_description

--- a/doc/tutorials/sharing-http-server.md
+++ b/doc/tutorials/sharing-http-server.md
@@ -5,10 +5,10 @@ through the board farm. You will do this all on a single host, so you can
 interact with all the components easily and get a complete picture of the board
 farm.
 
-First, start the board farm server. The server listens on port `2092` by
-default. Leave it running and continue in a new terminal window.
+First, start the board farm hub. The hub listens on port `2092` by default.
+Leave it running and continue in a new terminal window.
 ```console
-$ not-my-board serve
+$ not-my-board hub
 ```
 
 Now start the simple HTTP server, that will be shared with the board farm. Use

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ py.install_sources(
   'not_my_board/_http.py',
   'not_my_board/_jsonrpc.py',
   'not_my_board/_models.py',
-  'not_my_board/_serve.py',
+  'not_my_board/_hub.py',
   'not_my_board/_usbip.py',
   subdir: 'not_my_board',
 )

--- a/not_my_board/__init__.py
+++ b/not_my_board/__init__.py
@@ -1,1 +1,1 @@
-from ._serve import asgi_app
+from ._hub import asgi_app

--- a/not_my_board/_export.py
+++ b/not_my_board/_export.py
@@ -19,14 +19,14 @@ import not_my_board._util as util
 logger = logging.getLogger(__name__)
 
 
-async def export(server_url, place):
-    async with Exporter(server_url, place) as exporter:
+async def export(hub_url, place):
+    async with Exporter(hub_url, place) as exporter:
         await exporter.serve_forever()
 
 
 class Exporter:
-    def __init__(self, server_url, export_desc_path):
-        self._server_url = server_url
+    def __init__(self, hub_url, export_desc_path):
+        self._hub_url = hub_url
         self._ip_to_tasks_map = {}
         export_desc_content = export_desc_path.read_text()
         self._place = models.ExportDesc(**util.toml_loads(export_desc_content))
@@ -57,7 +57,7 @@ class Exporter:
                 )
             )
 
-            url = f"{self._server_url}/ws-exporter"
+            url = f"{self._hub_url}/ws-exporter"
             auth = "Bearer dummy-token-1"
             self._ws = await stack.enter_async_context(util.ws_connect(url, auth))
             self._ws_server = jsonrpc.Server(self._ws.send, self._receive_iter(), self)

--- a/not_my_board/_hub.py
+++ b/not_my_board/_hub.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 valid_tokens = ("dummy-token-1", "dummy-token-2")
 
 
-def serve():
+def hub():
     asgineer.run(asgi_app, "uvicorn", ":2092")
 
 

--- a/not_my_board/cli/__init__.py
+++ b/not_my_board/cli/__init__.py
@@ -9,7 +9,7 @@ import not_my_board._client as client
 import not_my_board._util as util
 from not_my_board._agent import agent
 from not_my_board._export import export
-from not_my_board._serve import serve
+from not_my_board._hub import hub
 
 try:
     from ..__about__ import __version__
@@ -40,21 +40,21 @@ def main():
             "-v", "--verbose", action="store_true", help="Enable debug logs"
         )
 
-    subparser = add_subcommand("serve", help="start the board farm server")
+    subparser = add_subcommand("hub", help="start the board farm hub")
     subparser.set_defaults(verbose=True)
 
     subparser = add_subcommand(
         "export", help="make connected boards available in the board farm"
     )
     subparser.set_defaults(verbose=True)
-    subparser.add_argument("server_url", help="http(s) URL of the server")
+    subparser.add_argument("hub_url", help="http(s) URL of the hub")
     subparser.add_argument(
         "export_description", type=pathlib.Path, help="path to a export description"
     )
 
     subparser = add_subcommand("agent", help="start an agent")
     subparser.set_defaults(verbose=True)
-    subparser.add_argument("server_url", help="http(s) URL of the server")
+    subparser.add_argument("hub_url", help="http(s) URL of the hub")
 
     subparser = add_subcommand("reserve", help="reserve a place")
     add_verbose_arg(subparser)
@@ -133,16 +133,16 @@ def main():
         pass
 
 
-def _serve_command(_):
-    serve()
+def _hub_command(_):
+    hub()
 
 
 async def _export_command(args):
-    await export(args.server_url, args.export_description)
+    await export(args.hub_url, args.export_description)
 
 
 async def _agent_command(args):
-    await agent(args.server_url)
+    await agent(args.hub_url)
 
 
 async def _reserve_command(args):

--- a/scripts/_vmctl/configure-vm.sh
+++ b/scripts/_vmctl/configure-vm.sh
@@ -6,8 +6,8 @@ main() {
     set -ex
 
     case "$vm" in
-    server)
-        setup_network_server
+    hub)
+        setup_network_hub
         install_project
         ;;
     exporter)
@@ -26,7 +26,7 @@ main() {
     esac
 }
 
-setup_network_server() {
+setup_network_hub() {
     ip link add name br0 type bridge
     ip link set eth1 up
     ip link set dev eth1 master br0

--- a/scripts/vmctl
+++ b/scripts/vmctl
@@ -24,7 +24,7 @@ positional arguments:
     configure  configure VM
     ssh        ssh into VM
     usb        control the USB device connected to the exporter
-  vm           select VM, one of "server", "exporter", "client"
+  vm           select VM, one of "hub", "exporter", "client"
   prog         program and arguments to run in VM
 EOF
     exit 0
@@ -199,7 +199,7 @@ run() {
     vm="$1"
 
     case "$vm" in
-        server)
+        hub)
             qemu_exec \
                 qemu_forward_ssh 4022 \
                 qemu_virtfs \
@@ -381,7 +381,7 @@ ssh_vm() {
     shift
 
     case "$vm" in
-        server) port=4022;;
+        hub) port=4022;;
         exporter) port=4122;;
         client) port=4222;;
         *) usage_error "unrecognized vm"


### PR DESCRIPTION
Since there are already a lot of "servers" in this code base (like HTTP server, JSONRPC server, UNIX Server, etc.), it can be confusing to use the same name for the board farm server. Rename "Server" to "Hub" to differentiate this server from the rest.