### PR TITLE
USB/IP: Bind usbip-host driver in exporter

### DIFF
--- a/not_my_board/_client.py
+++ b/not_my_board/_client.py
@@ -71,13 +71,6 @@ async def uevent(devpath):
 
     pipe = pathlib.Path("/run/usbip-refresh-" + busid)
     if pipe.exists():
-        print(f"Binding to usbip-host: {busid}", file=sys.stderr)
-        match_busid_path = pathlib.Path("/sys/bus/usb/drivers/usbip-host/match_busid")
-        if not match_busid_path.exists():
-            await _exec("modprobe", "usbip-host")
-        match_busid_path.write_text(f"add {busid}")
-        bind_path = pathlib.Path("/sys/bus/usb/drivers/usbip-host/bind")
-        bind_path.write_text(busid)
         with pipe.open("r+b", buffering=0) as f:
             f.write(b".")
     else:
@@ -88,13 +81,6 @@ async def uevent(devpath):
         except OSError:
             # fails for USB Hubs
             pass
-
-
-async def _exec(*args, **kwargs):
-    proc = await asyncio.create_subprocess_exec(*args, **kwargs)
-    await proc.communicate()
-    if proc.returncode:
-        raise RuntimeError(f"{args!r} exited with {proc.returncode}")
 
 
 def _find_import_description(name):

--- a/scripts/_vmctl/configure-vm.sh
+++ b/scripts/_vmctl/configure-vm.sh
@@ -73,8 +73,6 @@ EOF
 
     echo > /dev/mdev.seq
     echo > /dev/mdev.log
-    # mark busid 2-1, so it will be bound to usbip-host driver
-    echo > /run/usbip-refresh-2-1
 
     /etc/init.d/mdev restart
 }


### PR DESCRIPTION
Initially I wanted to run the exporter without root permissions, so I bound the usbip-host driver in the uevent command. The uevent command isn't triggered however, when the exporter starts, so the device might still be bound to its default driver.

To fix this move the driver binding to the exporter. The uevent command only notifies the exporter if a new device appears.

Additionally unbind the default driver in the exporter to handle the case when starting the exporter the first time. This might break sensible USB devices, but a USB device reset should fix it.