### PR TITLE
Fix endless loop in status subcommand

### DIFF
--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -301,12 +301,12 @@ def refresh_vhci_status():
     def status_paths():
         vhci_path = pathlib.Path("/sys/devices/platform/vhci_hcd.0")
         # the first status path doesn't have a suffix
-        yield vhci_path / "status"
+        status_path = vhci_path / "status"
+        count = itertools.count(1)
 
-        for num in itertools.count(1):
-            status_path = vhci_path / f"status.{num}"
-            if status_path.exists():
-                yield status_path
+        while status_path.exists():
+            yield status_path
+            status_path = vhci_path / f"status.{next(count)}"
 
     status_attached = 6  # VDEV_ST_USED
 

--- a/tests/test_usbip.py
+++ b/tests/test_usbip.py
@@ -151,6 +151,17 @@ async def test_usb_forwarding(vms):
                 # TODO attach still returns before the device is available.
                 # would be nice if it blocks until the device is ready.
                 await vms.client.ssh_poll("test -e /sys/bus/usb/devices/2-1")
+
+                result = await vms.client.ssh("not-my-board status")
+                status_str = result.stdout.rstrip()
+                status_lines = status_str.split("\n")
+                assert len(status_lines) == 2
+                header = status_lines[0].split()
+                status_line = status_lines[1].split()
+
+                assert header == ["Place", "Part", "Type", "Interface", "Status"]
+                assert status_line == ["qemu-usb", "flash-drive", "USB", "usb0", "Up"]
+
                 try:
                     await vms.exporter.usb_detach()
                     await vms.client.ssh_poll("! test -e /sys/bus/usb/devices/2-1")


### PR DESCRIPTION
There was no loop exit condition in the status command, so it busy looped forever. Fixed loop and added a test.