### PR TITLE
Docs: Add google search console verification code

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,3 +31,6 @@ myst_enable_extensions = [
 
 # exclude prompts and output from copies
 copybutton_exclude = ".linenos, .gp, .go"
+
+# add search console verification
+html_extra_path = ["googlef248cffc234a230d.html"]

--- a/doc/googlef248cffc234a230d.html
+++ b/doc/googlef248cffc234a230d.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef248cffc234a230d.html


### PR DESCRIPTION
The not-my-board documentation is still not indexed by google. Maybe the search console can ive me a hint what's wrong.