### PR TITLE
Agent: Fix handling of USB import timeout

### DIFF
--- a/not_my_board/_agent.py
+++ b/not_my_board/_agent.py
@@ -318,7 +318,7 @@ class UsbTunnel:
 
             try:
                 await asyncio.wait_for(ready_event.wait(), self._ready_timeout)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 logger.warning("%s: Attaching USB device timed out", self._name)
 
             self._stack = stack.pop_all()


### PR DESCRIPTION
The exception handler caught the wrong exception. The error occurs when you try to attach a place, that doesn't have all USB devices available.