### PR TITLE
Ignore pylint false positive (field() call)

### DIFF
--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -411,6 +411,7 @@ def serializable(cls):
     return cls
 
 
+# pylint: disable=invalid-field-call
 def no_init(default):
     return dataclasses.field(default=default, init=False)
 


### PR DESCRIPTION
The no_init() function wraps field() and is used only inside dataclasses.