### PR TITLE
USB/IP: Fix refresh pipe cleanup

### DIFF
--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -495,7 +495,7 @@ async def _refresh_task(device):
                 await pipe.read(4096)
                 device.refresh()
     finally:
-        tmp_path.unlink()
+        pipe_path.unlink()
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
Delete real pipe instead of temporary pipe.
