### PR TITLE
vmctl: Increase timeout waiting for SSH

### DIFF
--- a/scripts/vmctl
+++ b/scripts/vmctl
@@ -343,9 +343,9 @@ configure() {
 wait_for_sshd() {
     vm="$1"
     i=0
-    while [ "$i" -lt 30 ]; do
+    while [ "$i" -lt 70 ]; do
         if ssh_vm "$vm" true 2>/dev/null; then
-            break
+            return
         fi
         i=$((i + 1))
         if [ -e /dev/kvm ]; then
@@ -355,6 +355,9 @@ wait_for_sshd() {
             sleep 5
         fi
     done
+
+    echo "error: VM doesn't respond" >&2
+    return 1
 }
 
 ssh() {


### PR DESCRIPTION
When running the tests in Github Actions, the configure task would
sporadically fail, because sshd in the VM was started a bit too late.
The error message was:

        kex_exchange_identification: Connection closed by remote host

Add a more descriptive error message and increase the timeout.
