### PR TITLE
http: Fix no_proxy env variable parsing

### DIFF
--- a/not_my_board/_http.py
+++ b/not_my_board/_http.py
@@ -37,9 +37,12 @@ class Client:
 
         if proxies is None:
             proxies = urllib.request.getproxies()
-        self._proxies = {
-            scheme: self._parse_url(url) for scheme, url in proxies.items()
-        }
+
+        self._proxies = {}
+        for scheme in ("http", "https"):
+            if scheme in proxies:
+                self._proxies[scheme] = self._parse_url(proxies[scheme])
+        self._no_proxy = proxies.get("no", "")
 
     async def get_json(self, url):
         return await self._request_json("GET", url)
@@ -125,7 +128,7 @@ class Client:
 
     def _get_proxy(self, url):
         proxy = self._proxies.get(url.scheme)
-        if proxy and not is_proxy_disabled(url.host, self._proxies.get("no", "")):
+        if proxy and not is_proxy_disabled(url.host, self._no_proxy):
             return proxy
         return None
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -26,6 +26,17 @@ async def test_proxy_connect(tinyproxy):
         assert response == {"places": []}
 
 
+async def test_proxy_ignore():
+    async with sh_task("not-my-board hub", "hub"):
+        await wait_for_ports(2092)
+
+        client = http.Client(
+            proxies={"http": "http://non-existing.localhost", "no": "127.0.0.1"}
+        )
+        response = await client.get_json("http://127.0.0.1:2092/api/v1/places")
+        assert response == {"places": []}
+
+
 async def test_proxy_connect_https(tinyproxy):
     root_key = project_dir / "tests/.cache/not-my-board-root-ca.key"
     root_cert = project_dir / "tests/.cache/not-my-board-root-ca.crt"


### PR DESCRIPTION
Don't parse no_proxy as a URL, because it's just a pattern. This fixes
an error, when no_proxy is set:

    ValueError: Unknown scheme ""
