### PR TITLE
Switch to ruff

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -27,8 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[test]
+    - name: Lint with Ruff
+      run: ruff check not_my_board tests doc
     - name: Check format with Black
-      run: black --check --quiet not_my_board tests doc
+      run: black --check not_my_board tests doc
     - name: Check import statement order with isort
       run: isort --check not_my_board tests
     - name: Check spelling

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -27,8 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install .[test]
-    - name: Lint with Pylint
-      run: pylint --score=n not_my_board tests
     - name: Check format with Black
       run: black --check --quiet not_my_board tests doc
     - name: Check import statement order with isort

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,10 +9,10 @@ import subprocess
 project_dir = pathlib.Path(__file__).parents[1]
 
 project = "not-my-board"
-copyright = "2023-present, Simon Holesch"
+copyright = "2023-present, Simon Holesch"  # noqa: A001
 author = "Simon Holesch"
 release = subprocess.run(
-    "scripts/get_version", cwd=project_dir, capture_output=True, text=True, check=True
+    "./scripts/get_version", cwd=project_dir, capture_output=True, text=True, check=True
 ).stdout.strip()
 
 extensions = [

--- a/not_my_board/_agent.py
+++ b/not_my_board/_agent.py
@@ -5,7 +5,6 @@ import contextlib
 import functools
 import ipaddress
 import logging
-import os
 import pathlib
 import shutil
 import traceback
@@ -50,7 +49,7 @@ class _AgentIO:
 
         connection_handler = functools.partial(self._handle_unix_client, api_obj)
         async with util.UnixServer(connection_handler, socket_path) as unix_server:
-            os.chmod(socket_path, 0o660)
+            socket_path.chmod(0o660)
             try:
                 shutil.chown(socket_path, group="not-my-board")
             except Exception as e:

--- a/not_my_board/_agent.py
+++ b/not_my_board/_agent.py
@@ -254,7 +254,6 @@ def _filter_places(import_description, places):
     return candidates
 
 
-# pylint: disable=too-many-locals
 def _create_tunnel_descriptions(import_description, place, matching):
     place_name = import_description.name
     proxy = (place.host, place.port)

--- a/not_my_board/_auth/_login.py
+++ b/not_my_board/_auth/_login.py
@@ -97,7 +97,6 @@ class _TokenStore(util.ContextStack):
         self._path = path
 
     async def _context_stack(self, stack):
-        # pylint: disable-next=consider-using-with  # false positive
         self._f = stack.enter_context(self._path.open("r+"))
         await stack.enter_async_context(util.flock(self._f))
         content = self._f.read()

--- a/not_my_board/_auth/_openid.py
+++ b/not_my_board/_auth/_openid.py
@@ -157,9 +157,8 @@ class Validator:
         key_id = unverified_token["header"]["kid"]
         issuer = unverified_token["payload"]["iss"]
 
-        if self._trusted_issuers is not None:
-            if issuer not in self._trusted_issuers:
-                raise RuntimeError(f"Unknown issuer: {issuer}")
+        if self._trusted_issuers is not None and issuer not in self._trusted_issuers:
+            raise RuntimeError(f"Unknown issuer: {issuer}")
 
         identity_provider = await IdentityProvider.from_url(issuer, self._http)
         jwk_set_raw = await self._http.get_json(identity_provider.jwks_uri)

--- a/not_my_board/_client.py
+++ b/not_my_board/_client.py
@@ -2,13 +2,15 @@
 
 import asyncio
 import contextlib
+import logging
 import os
 import pathlib
-import sys
 
 import not_my_board._jsonrpc as jsonrpc
 import not_my_board._models as models
 import not_my_board._util as util
+
+logger = logging.getLogger(__name__)
 
 
 async def reserve(import_description, with_name=None):
@@ -71,7 +73,7 @@ async def uevent(devpath):
         with pipe.open("r+b", buffering=0) as f:
             f.write(b".")
     else:
-        print(f"Loading default driver: {devname}", file=sys.stderr)
+        logger.info("Loading default driver: %s", devname)
         probe_path = pathlib.Path("/sys/bus/usb/drivers_probe")
         probe_path.write_text(devname)
 
@@ -101,7 +103,7 @@ def _find_import_description(name, with_name=None):
             if not import_description_file.is_file():
                 raise ValueError(f"No import description file exists for name {name}")
 
-    reservation_name = import_description_file.stem if not with_name else with_name
+    reservation_name = with_name if with_name else import_description_file.stem
     import_description_content = util.toml_loads(import_description_file.read_text())
     import_description = models.ImportDesc(
         name=reservation_name, **import_description_content

--- a/not_my_board/_http.py
+++ b/not_my_board/_http.py
@@ -435,7 +435,6 @@ def _is_proxy_disabled_host(host, patterns):
     return False
 
 
-# pylint: disable=protected-access
 # remove, if Python version < 3.11 is no longer supported
 async def _start_tls(writer, url):
     if hasattr(writer, "start_tls"):

--- a/not_my_board/_hub.py
+++ b/not_my_board/_hub.py
@@ -37,8 +37,6 @@ async def asgi_app(scope, receive, send):
         # before handing over to asgineer
         await _handle_lifespan(scope, receive, send)
     else:
-        # to_asgi() decorator adds extra arguments
-        # pylint: disable-next=too-many-function-args
         await _handle_request(scope, receive, send)
 
 
@@ -114,7 +112,6 @@ def require_role(role):
 
 
 class Hub:
-    # pylint: disable=too-many-locals
     def __init__(self, config=None, http_client=None):
         self._places = {}
         self._exporters = {}

--- a/not_my_board/_jsonrpc/_protocol.py
+++ b/not_my_board/_jsonrpc/_protocol.py
@@ -217,7 +217,6 @@ def hidden(func):
     keep it public for local users, otherwise just use a leading underscore in
     the method name.
     """
-    # pylint: disable=protected-access
     func._jsonrpc_hidden = True
     return func
 

--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -97,10 +97,9 @@ class UsbIpDevice(util.ContextStack):
         self._refresh_event.set()
 
     async def _context_stack(self, stack):
-        async with contextlib.AsyncExitStack() as stack:
-            await stack.enter_async_context(self._lock)
-            await self.available()
-            stack.callback(self.stop_export)
+        await stack.enter_async_context(self._lock)
+        await self.available()
+        stack.callback(self.stop_export)
 
     def stop_export(self):
         if self._is_exported:
@@ -203,15 +202,15 @@ class UsbIpDevice(util.ContextStack):
     usbip_status = _SysfsFileInt()
     busnum = _SysfsFileInt()
     devnum = _SysfsFileInt()
-    idVendor = _SysfsFileHex()
-    idProduct = _SysfsFileHex()
-    bcdDevice = _SysfsFileHex()
-    bDeviceClass = _SysfsFileHex()
-    bDeviceSubClass = _SysfsFileHex()
-    bDeviceProtocol = _SysfsFileHex()
-    bConfigurationValue = _SysfsFileHex(default=0)
-    bNumConfigurations = _SysfsFileHex()
-    bNumInterfaces = _SysfsFileHex(default=0)
+    idVendor = _SysfsFileHex()  # noqa: N815
+    idProduct = _SysfsFileHex()  # noqa: N815
+    bcdDevice = _SysfsFileHex()  # noqa: N815
+    bDeviceClass = _SysfsFileHex()  # noqa: N815
+    bDeviceSubClass = _SysfsFileHex()  # noqa: N815
+    bDeviceProtocol = _SysfsFileHex()  # noqa: N815
+    bConfigurationValue = _SysfsFileHex(default=0)  # noqa: N815
+    bNumConfigurations = _SysfsFileHex()  # noqa: N815
+    bNumInterfaces = _SysfsFileHex(default=0)  # noqa: N815
 
 
 async def _exec(*args, **kwargs):
@@ -296,11 +295,10 @@ def _port_num_to_vhci_port(port_num, speed):
 
 def detach(vhci_port):
     detach_path = pathlib.Path("/sys/devices/platform/vhci_hcd.0/detach")
-    try:
+
+    # ignore error, if not attached anymore
+    with contextlib.suppress(OSError):
         detach_path.write_text(f"{vhci_port}")
-    except OSError:
-        # not attached anymore
-        pass
 
 
 async def refresh_vhci_status():
@@ -395,6 +393,7 @@ def serializable(cls):
     cls._struct = struct.Struct(format_str)
     cls._to_strip = to_strip
 
+    # ruff: noqa: N807
     def __bytes__(self):
         return self._struct.pack(
             *(getattr(self, f.name) for f in dataclasses.fields(self))
@@ -410,11 +409,10 @@ def serializable(cls):
                 if field.name in cls._to_strip:
                     value = value.rstrip(b"\0")
                 init_values.append(value)
-            else:
-                if value != field.default:
-                    raise ProtocolError(
-                        f"Expected {field.name}={field.default}, got={value}"
-                    )
+            elif value != field.default:
+                raise ProtocolError(
+                    f"Expected {field.name}={field.default}, got={value}"
+                )
 
         # pylint: disable=E1120
         # No value for argument 'cls': false positive
@@ -452,15 +450,15 @@ class ImportReply(Header):
     busnum: UInt32
     devnum: UInt32
     speed: UInt32
-    idVendor: UInt16
-    idProduct: UInt16
-    bcdDevice: UInt16
-    bDeviceClass: UInt8
-    bDeviceSubClass: UInt8
-    bDeviceProtocol: UInt8
-    bConfigurationValue: UInt8
-    bNumConfigurations: UInt8
-    bNumInterfaces: UInt8
+    idVendor: UInt16  # noqa: N815
+    idProduct: UInt16  # noqa: N815
+    bcdDevice: UInt16  # noqa: N815
+    bDeviceClass: UInt8  # noqa: N815
+    bDeviceSubClass: UInt8  # noqa: N815
+    bDeviceProtocol: UInt8  # noqa: N815
+    bConfigurationValue: UInt8  # noqa: N815
+    bNumConfigurations: UInt8  # noqa: N815
+    bNumInterfaces: UInt8  # noqa: N815
 
     @classmethod
     def from_device(cls, device):

--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -371,9 +371,6 @@ class Char(bytes):
         return Annotated[bytes, StructStr(f"{key}s")]
 
 
-# pylint: disable=W0212,E1101
-# - accessing protected member of cls, e.g. cls._struct
-# - 'serializable' has no '_struct' member
 def serializable(cls):
     cls = dataclasses.dataclass(cls)
 
@@ -414,8 +411,6 @@ def serializable(cls):
                     f"Expected {field.name}={field.default}, got={value}"
                 )
 
-        # pylint: disable=E1120
-        # No value for argument 'cls': false positive
         return cls(*init_values)
 
     cls.__bytes__ = __bytes__
@@ -424,7 +419,6 @@ def serializable(cls):
     return cls
 
 
-# pylint: disable=invalid-field-call
 def no_init(default):
     return dataclasses.field(default=default, init=False)
 
@@ -502,7 +496,6 @@ async def _open_read_pipe(*args, **kwargs):
         yield reader
 
 
-# pylint: disable=import-outside-toplevel
 async def _main():
     import argparse
 

--- a/not_my_board/_util/_asyncio.py
+++ b/not_my_board/_util/_asyncio.py
@@ -200,11 +200,9 @@ class Server:
         except Exception:
             traceback.print_exc()
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 writer.close()
                 await writer.wait_closed()
-            except Exception:
-                pass
 
     async def _start(self):
         return await asyncio.start_server(self._on_connect, *self._args, **self._kwargs)
@@ -232,7 +230,7 @@ class ContextStack:
     """
 
     async def _context_stack(self, stack):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     async def __aenter__(self):
         async with contextlib.AsyncExitStack() as stack:

--- a/not_my_board/_util/_matching.py
+++ b/not_my_board/_util/_matching.py
@@ -1,4 +1,3 @@
-# pylint: disable=invalid-name
 # ruff: noqa: N803
 # ruff: noqa: N806
 import collections

--- a/not_my_board/_util/_matching.py
+++ b/not_my_board/_util/_matching.py
@@ -1,4 +1,6 @@
 # pylint: disable=invalid-name
+# ruff: noqa: N803
+# ruff: noqa: N806
 import collections
 
 INFINITY = float("inf")
@@ -81,10 +83,11 @@ def find_matching(G):
         for v in G[u]:
             # Go from v to u over a matched edge. next_u is None, if v is free.
             next_u = M_reverse.get(v)
-            if layer[next_u] == layer[u] + 1:
-                if next_u is None or depth_first_search(next_u):
-                    M[u], M_reverse[v] = v, u
-                    return True
+            if layer[next_u] == layer[u] + 1 and (
+                next_u is None or depth_first_search(next_u)
+            ):
+                M[u], M_reverse[v] = v, u
+                return True
 
         # No path found for this u. Mark it, to not try again.
         layer[u] = INFINITY
@@ -98,21 +101,3 @@ def find_matching(G):
                 depth_first_search(u)
 
     return M
-
-
-def _main():
-    G = {
-        "U0": ["V0", "V1"],
-        "U1": ["V0", "V4"],
-        "U2": ["V2", "V3"],
-        "U3": ["V0", "V4"],
-        "U4": ["V1", "V3"],
-    }
-
-    M = find_matching(G)
-    for k, v in M.items():
-        print(f"{k} -> {v}")
-
-
-if __name__ == "__main__":
-    _main()

--- a/not_my_board/cli/__init__.py
+++ b/not_my_board/cli/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: T201
 import argparse
 import asyncio
 import json
@@ -19,10 +20,11 @@ except ModuleNotFoundError:
     __version__ = "dev"
 
 
-TOKEN_STORE_PATH = "/var/lib/not-my-board/auth_tokens.json"
+TOKEN_STORE_PATH = "/var/lib/not-my-board/auth_tokens.json"  # noqa: S105
 
 
 # pylint: disable=too-many-statements
+# ruff: noqa: PLR0915
 def main():
     parser = argparse.ArgumentParser(description="Setup, manage and use a board farm")
     parser.add_argument(
@@ -218,7 +220,7 @@ async def _uevent_command(args):
 
 async def _login_command(args):
     http_client = http.Client(args.cacert)
-    token_store_path = "/var/lib/not-my-board/auth_tokens.json"
+    token_store_path = "/var/lib/not-my-board/auth_tokens.json"  # noqa: S105
     async with auth.LoginFlow(args.hub_url, http_client, token_store_path) as login:
         print(
             f"{Format.BOLD}"

--- a/not_my_board/cli/__init__.py
+++ b/not_my_board/cli/__init__.py
@@ -23,7 +23,6 @@ except ModuleNotFoundError:
 TOKEN_STORE_PATH = "/var/lib/not-my-board/auth_tokens.json"  # noqa: S105
 
 
-# pylint: disable=too-many-statements
 # ruff: noqa: PLR0915
 def main():
     parser = argparse.ArgumentParser(description="Setup, manage and use a board farm")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = [
     "pytest",
     "pytest-asyncio ~= 0.21.2",
     "pytest-cov",
+    "ruff",
 ]
 docs = [
     "furo",
@@ -111,3 +112,100 @@ generated-members = [
 
 [tool.isort]
 profile = "black"
+
+[tool.ruff.lint]
+select = [
+    # Pyflakes
+    "F",
+    # pycodestyle
+    "E", "W",
+    # isort
+    "I",
+    # pep8-naming
+    "N",
+    # pyupgrade
+    "UP",
+    # flake8-2020
+    "YTT",
+    # flake8-async
+    "ASYNC",
+    # flake8-bandit
+    "S",
+    # flake8-bugbear
+    "B",
+    # flake8-builtins
+    "A",
+    # flake8-comprehensions
+    "C4",
+    # flake8-implicit-str-concat
+    "ISC",
+    # flake8-logging
+    "LOG",
+    # flake8-logging-format
+    "G",
+    # flake8-pie
+    "PIE",
+    # flake8-print
+    "T20",
+    # flake8-pytest-style
+    "PT",
+    # flake8-raise
+    "RSE",
+    # flake8-simplify
+    "SIM",
+    # flake8-unused-arguments
+    "ARG",
+    # flake8-use-pathlib
+    "PTH",
+    # Pylint
+    "PL",
+    # flynt
+    "FLY",
+    # refurb
+    "FURB",
+    # Ruff-specific rules
+    "RUF",
+]
+ignore = [
+    # "Async functions should not open files with blocking methods like open"
+    # -> doesn't seem to be a problem now, might revisit later
+    "ASYNC230",
+    # "Line too long"
+    # -> complains for long strings, rely on black
+    "E501",
+    # "for loop variable overwritten by assignment target"
+    "PLW2901",
+    # "open() should be replaced by Path.open()"
+    # -> just creating a Path object to open a file is overkill
+    "PTH123",
+    # "subprocess call: check for execution of untrusted input"
+    # -> false positives
+    "S603",
+    # "Use ternary operator instead of if-else-block"
+    # -> can make the code less readable
+    "SIM108",
+    # "Use a single with statement with multiple contexts instead of nested
+    #  with statements"
+    # -> only useful with Python version >= 3.10, when you can break the
+    #    statement into multiple lines
+    "SIM117",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = [
+    # "{name} imported but unused"
+    # -> modules are imported in __init__.py to re-export them
+    "F401",
+]
+"tests/**.py" = [
+    # "Magic value used in comparison"
+    # -> magic values are OK for tests
+    "PLR2004",
+    # "pytest.raises() block should contain a single simple statement"
+    # -> there are a few cases, that catch the exception raised in a context
+    #    manager (util.background_task)
+    "PT012",
+    # "Use of assert detected"
+    # -> usage is expected in tests
+    "S101",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ test = [
     "codespell",
     "isort",
     "mypy",
-    "pylint",
-    "pylint-pytest",
     "pytest",
     "pytest-asyncio ~= 0.21.2",
     "pytest-cov",
@@ -75,40 +73,6 @@ requires = ["meson-python"]
 addopts = ["--quiet"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-
-[tool.pylint.MASTER]
-load-plugins = "pylint_pytest"
-
-[tool.pylint."MESSAGES CONTROL"]
-disable = [
-    "attribute-defined-outside-init",
-    "broad-exception-caught",
-    "contextmanager-generator-missing-cleanup",
-    "fixme",
-    "missing-class-docstring",
-    "missing-function-docstring",
-    "missing-module-docstring",
-    "no-else-raise",
-    "no-else-return",
-    "too-few-public-methods",
-    "too-many-arguments",
-    "too-many-instance-attributes",
-    "unspecified-encoding",
-]
-# allow short names
-variable-rgx = "^_{,2}[a-z][a-z0-9_]{,30}$"
-argument-rgx = "^_{,2}[a-z][a-z0-9_]{,30}$"
-attr-rgx = "^_{,2}[a-z][a-z0-9_]{,30}$"
-# allow any length for functions (e.g. test function names can be quite
-# long)
-function-rgx = "^_{,2}[a-z][a-z0-9_]*$"
-# pylint doesn't support lazy_import()
-generated-members = [
-    "websockets",
-    "pydantic",
-    "ImportRequest",
-    "ImportReply",
-]
 
 [tool.isort]
 profile = "black"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -206,7 +206,7 @@ class FakeAgentIO:
             del self.port_forwards[local_port]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 async def agent_io():
     io = FakeAgentIO()
     async with agentmodule.Agent(HUB_URL, io) as agent:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -179,12 +179,12 @@ class FakeWebsocket:
         await self._send(data)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def http_client():
-    yield FakeHttpClient()
+    return FakeHttpClient()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def hub(http_client):
     config = {
         "auth": {
@@ -198,10 +198,10 @@ def hub(http_client):
             ],
         },
     }
-    yield hubmodule.Hub(config, http_client)
+    return hubmodule.Hub(config, http_client)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def token_store_path():
     path = pathlib.Path(__file__).parent / "auth_tokens.json"
     path.unlink(missing_ok=True)
@@ -256,7 +256,7 @@ async def test_login_success(hub, http_client, token_store_path):
 
 
 @pytest.mark.parametrize(
-    "claims,is_allowed",
+    ("claims", "is_allowed"),
     [
         ({"sub": USER_NAME}, True),
         ({"sub": "unauthorized-user"}, False),
@@ -344,7 +344,7 @@ async def test_permission_lost(hub, http_client, token_store_path, fake_time):
     assert "Permission lost" in str(execinfo.value)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def fake_time(monkeypatch):
     fake_time_ = FakeTime()
     fake_datetime = fake_time_.fake_datetime()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -91,7 +91,7 @@ async def test_proxy_connect_https(tinyproxy):
 
 
 @pytest.mark.parametrize(
-    "host,no_proxy_env,expected",
+    ("host", "no_proxy_env", "expected"),
     [
         # Test cases taken from curl
         ("www.example.com", "localhost,.example.com,.example.de", True),

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -58,7 +58,6 @@ class FakeExporter:
         return self._allowed_ips
 
 
-# pylint: disable=redefined-outer-name
 @contextlib.asynccontextmanager
 async def register_exporter(hub, ip=DEFAULT_EXPORTER_IP):
     rpc1, rpc2 = fake_rpc_pair()
@@ -80,7 +79,6 @@ async def test_register_exporter(hub):
     assert len(places["places"]) == 0
 
 
-# pylint: disable=redefined-outer-name
 @contextlib.asynccontextmanager
 async def register_agent(hub, ip=DEFAULT_AGENT_IP):
     rpc1, rpc2 = fake_rpc_pair()

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -13,9 +13,9 @@ DEFAULT_EXPORTER_IP = "3.1.1.1"
 DEFAULT_AGENT_IP = "6.1.1.1"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def hub():
-    yield hubmodule.Hub()
+    return hubmodule.Hub()
 
 
 async def test_no_places_on_startup(hub):
@@ -135,7 +135,7 @@ async def test_all_places_disappear_while_trying_to_reserve(hub):
             candidate_ids = [places["places"][0]["id"]]
             await agent.reserve(candidate_ids)
 
-            with pytest.raises(Exception) as execinfo:
+            with pytest.raises(jsonrpc.RemoteError) as execinfo:
                 # try to reserve same place again
                 coro = agent.reserve(candidate_ids)
                 async with util.background_task(coro):

--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -308,7 +308,6 @@ async def test_either_args_or_kwargs(fakes):
 
 async def test_prevent_hidden_function_call(fakes):
     with pytest.raises(AttributeError) as execinfo:
-        # pylint: disable=protected-access
         await fakes.channel._hidden()
     assert "invalid attribute" in str(execinfo.value)
 

--- a/tests/test_jsonrpc.py
+++ b/tests/test_jsonrpc.py
@@ -73,7 +73,7 @@ class FakeTransport:
 Fakes = collections.namedtuple("Fakes", ["channel", "api", "transport"])
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 async def fakes():
     transport = FakeTransport()
     api = FakeApi()


### PR DESCRIPTION
Ruff can replace pylint as a linter. Ruff finishes in an instant, while pylint takes > 10 s to check all files.