### PR TITLE
Hub: Rename Config File to hub.toml

### DIFF
--- a/doc/how-to-guides/deploy-hub.md
+++ b/doc/how-to-guides/deploy-hub.md
@@ -47,7 +47,7 @@ Add the OpenID configuration information to the *Hub* configuration. For example
 when using Keycloak:
 
 ```{code-block} toml
-:caption: /etc/not-my-board/not-my-board-hub.toml
+:caption: /etc/not-my-board/hub.toml
 
 [auth]
 issuer = "http://keycloak.example.com/realms/master"
@@ -61,7 +61,7 @@ Then add permissions for users. You can get the claims from users after they log
 in with `not-my-board login`, or from the OpenID provider.
 
 ```{code-block} toml
-:caption: /etc/not-my-board/not-my-board-hub.toml
+:caption: /etc/not-my-board/hub.toml
 
 # [...]
 

--- a/doc/how-to-guides/import-places-in-ci.md
+++ b/doc/how-to-guides/import-places-in-ci.md
@@ -23,7 +23,7 @@ system generate an ID token for your job.
 
 For example with GitHub Actions, add permissions to the *Hub* config:
 ```{code-block} toml
-:caption: /etc/not-my-board/not-my-board-hub.toml
+:caption: /etc/not-my-board/hub.toml
 
 [...]
 

--- a/doc/how-to-guides/set-up-exporter.md
+++ b/doc/how-to-guides/set-up-exporter.md
@@ -11,7 +11,7 @@ added (replace `<my-hub-address>` with the address or domain name of the *Hub*):
 Description=Board Farm Exporter For Place %I
 
 [Service]
-ExecStart=/usr/local/bin/not-my-board export https://<my-hub-address> /etc/not-my-board/%i.toml
+ExecStart=/usr/local/bin/not-my-board export https://<my-hub-address> /etc/not-my-board/export-descriptions/%i.toml
 Restart=on-failure
 RestartSec=10s
 
@@ -19,9 +19,9 @@ RestartSec=10s
 WantedBy=multi-user.target
 ```
 
-Create the export description in `/etc/not-my-board/`, for example:
+Create the export description in `/etc/not-my-board/export-descriptions`, for example:
 ```{code-block} toml
-:caption: /etc/not-my-board/example.toml
+:caption: /etc/not-my-board/export-descriptions/example.toml
 
 port = 29201
 
@@ -50,6 +50,6 @@ $ sudo systemctl enable --now not-my-board-exporter@example
 
 :::{note}
 The `example` instance name in the above command refers to the export
-description in `/etc/not-my-board/`. By changing the instance name, you can
-easily add new *Exporter* instances.
+description in `/etc/not-my-board/export-descriptions`. By changing the instance
+name, you can easily add new *Exporter* instances.
 :::

--- a/doc/how-to-guides/usb-export.md
+++ b/doc/how-to-guides/usb-export.md
@@ -89,7 +89,7 @@ $ sudo dmesg | grep usb
 Now create the export description with the `usbid` of the USB device. If your
 board has more than one USB interface, you can of course add them all:
 ```{code-block} toml
-:caption: /etc/not-my-board/example.toml
+:caption: /etc/not-my-board/export-descriptions/example.toml
 
 port = 2192
 
@@ -101,5 +101,5 @@ usb.usb-serial = { usbid = "3-8" }
 
 Finally, use the export description to register the place in the board farm:
 ```console
-$ sudo not-my-board export http://<board-farm-address>:2092 /etc/not-my-board/example.toml
+$ sudo not-my-board export http://<board-farm-address>:2092 /etc/not-my-board/export-descriptions/example.toml
 ```

--- a/doc/reference/hub-configuration.md
+++ b/doc/reference/hub-configuration.md
@@ -1,9 +1,8 @@
 # Hub Configuration
 
-The *Hub* loads its configuration on startup from
-`/etc/not-my-board/not-my-board-hub.toml`. You can override this location with
-the environment variable `NOT_MY_BOARD_HUB_CONFIG`. The file format is
-[TOML](https://toml.io/en/).
+The *Hub* loads its configuration on startup from `/etc/not-my-board/hub.toml`.
+You can override this location with the environment variable
+`NOT_MY_BOARD_HUB_CONFIG`. The file format is [TOML](https://toml.io/en/).
 
 ## Settings
 
@@ -94,7 +93,7 @@ The following roles are defined:
 
 Here's an example of a *Hub* configuration:
 ```{code-block} toml
-:caption: /etc/not-my-board/not-my-board-hub.toml
+:caption: /etc/not-my-board/hub.toml
 
 log_level = "info"
 
@@ -114,7 +113,7 @@ roles = ["importer"]
 
 And here's an example with Microsoft Entra ID as OpenID provider:
 ```{code-block} toml
-:caption: /etc/not-my-board/not-my-board-hub.toml
+:caption: /etc/not-my-board/hub.toml
 log_level = "info"
 
 [auth]

--- a/not_my_board/_hub.py
+++ b/not_my_board/_hub.py
@@ -48,7 +48,7 @@ async def _handle_lifespan(scope, receive, send):
             try:
                 config_file = os.environ.get("NOT_MY_BOARD_HUB_CONFIG")
                 if not config_file:
-                    config_file = "/etc/not-my-board/not-my-board-hub.toml"
+                    config_file = "/etc/not-my-board/hub.toml"
                 config_file = pathlib.Path(config_file)
 
                 if config_file.exists():


### PR DESCRIPTION
Rename the file from `not-my-board-hub.toml` to `hub.toml`, because it's easier to type. Move all the export descriptions into a subdirectory in `/etc/not-my-board/`, so the names can't collide with config files like `hub.toml`.