### PR TITLE
Auto Return Reservation

### DIFF
--- a/doc/reference/import-description.md
+++ b/doc/reference/import-description.md
@@ -9,6 +9,37 @@ The *Agent* uses this import description to reserve one of the matching
 
 ## Settings
 
+### `auto_return_time`
+
+**Type:** String \
+**Required:** No \
+**Default:** `"10h"`
+
+Delay after which the reservation is automatically returned. The timer is reset
+after editing the import description with the `not-my-board edit` command. The
+time format uses a sequence of positive integers followed by lowercase time
+units:
+
+:::{table}
+:align: left
+
+Unit | Description
+---- | -----------
+`w`  | weeks
+`d`  | days
+`h`  | hours
+`m`  | minutes
+`s`  | seconds (optional)
+:::
+
+Units must appear in descending order of significance (e.g. weeks before days).
+A delay of `0` disables the auto return.
+
+Examples:
+- `600`: 600 seconds or 10 minutes
+- `10m`: 10 minutes
+- `1h30m`: 1 hour 30 minutes (90 minutes)
+
 ### `parts`
 
 **Type:** Table \

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ py.install_sources(
   'not_my_board/_util/__init__.py',
   'not_my_board/_util/_asyncio.py',
   'not_my_board/_util/_matching.py',
+  'not_my_board/_util/_parser.py',
   subdir: 'not_my_board/_util',
 )
 

--- a/not_my_board/_models.py
+++ b/not_my_board/_models.py
@@ -21,6 +21,7 @@ class ImportedPart(pydantic.BaseModel):
 
 class ImportDesc(pydantic.BaseModel):
     name: str
+    auto_return_time: str = "10h"
     parts: Dict[str, ImportedPart]
 
 

--- a/not_my_board/_util/__init__.py
+++ b/not_my_board/_util/__init__.py
@@ -12,6 +12,7 @@ from ._asyncio import (
     run_concurrently,
 )
 from ._matching import find_matching
+from ._parser import parse_time
 
 try:
     from tomllib import loads as toml_loads

--- a/not_my_board/_util/_parser.py
+++ b/not_my_board/_util/_parser.py
@@ -1,0 +1,33 @@
+import re
+
+TIME_UNIT_TO_SECONDS = {
+    "seconds": 1,
+    "minutes": 60,
+    "hours": 60 * 60,
+    "days": 24 * 60 * 60,
+    "weeks": 7 * 24 * 60 * 60,
+}
+
+
+def parse_time(time_string):
+    if not time_string:
+        raise RuntimeError("Time is an empty string")
+
+    time_pattern = (
+        r"(?:(?P<weeks>\d+)w)?"
+        r"(?:(?P<days>\d+)d)?"
+        r"(?:(?P<hours>\d+)h)?"
+        r"(?:(?P<minutes>\d+)m)?"
+        r"(?:(?P<seconds>\d+)s?)?"
+    )
+
+    match = re.fullmatch(time_pattern, time_string)
+    if match is None:
+        raise RuntimeError("Invalid time format")
+
+    total_seconds = 0
+    for unit, value in match.groupdict().items():
+        if value:
+            total_seconds += int(value) * TIME_UNIT_TO_SECONDS[unit]
+
+    return total_seconds

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,3 +24,40 @@ async def blocking_task():
 
 async def failing_task():
     raise RuntimeError("Dummy Error")
+
+
+@pytest.mark.parametrize(
+    ("time_string", "seconds"),
+    [
+        ("10h", 10 * 60 * 60),
+        ("600", 600),
+        ("10m", 10 * 60),
+        ("1h30m", 1 * 60 * 60 + 30 * 60),
+        ("1h30m10s", 1 * 60 * 60 + 30 * 60 + 10),
+        ("2w3d4h", 2 * 7 * 24 * 60 * 60 + 3 * 24 * 60 * 60 + 4 * 60 * 60),
+    ],
+)
+async def test_parse_time(time_string, seconds):
+    assert util.parse_time(time_string) == seconds
+
+
+@pytest.mark.parametrize(
+    ("time_string"),
+    [
+        "1s10h",
+        "abc",
+        "h",
+        "10H",
+        "1a",
+    ],
+)
+async def test_parse_time_invalid(time_string):
+    with pytest.raises(RuntimeError) as execinfo:
+        util.parse_time(time_string)
+    assert "Invalid time format" in str(execinfo.value)
+
+
+async def test_parse_empty_time_string():
+    with pytest.raises(RuntimeError) as execinfo:
+        util.parse_time("")
+    assert "Time is an empty string" in str(execinfo.value)


### PR DESCRIPTION
It's easy to forget returning the reservation. Add an auto return timer, so that places are automatically returned after a configurable delay. The default delay is 10 hours.