### PR TITLE
pyproject: Require async-timeout version 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "asgineer",
-    "async-timeout; python_version < '3.11'",
+    "async-timeout ~= 5.0; python_version < '3.11'",
     "colorlog",
     "h11",
     "pydantic ~= 1.10",


### PR DESCRIPTION
Version 5 added support for reschedule, which is already used.