### PR TITLE
Fix USB Attach Retries for Python < 3.11

### DIFF
--- a/not_my_board/_agent.py
+++ b/not_my_board/_agent.py
@@ -503,7 +503,7 @@ class _UsbTunnel(_Tunnel):
                         self._proxy, USBIP_REMOTE, self.port_num, self.usbid
                     )
                     break
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 attach_timeout = min(2 * attach_timeout, 30)
 
     def is_attached(self):

--- a/not_my_board/_hub.py
+++ b/not_my_board/_hub.py
@@ -29,9 +29,9 @@ authenticator_var = contextvars.ContextVar("authenticator")
 
 
 def run_hub():
-    import socket
+    import socket  # noqa: PLC0415
 
-    import uvicorn
+    import uvicorn  # noqa: PLC0415
 
     with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)

--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -577,7 +577,7 @@ async def _open_read_pipe(*args, **kwargs):
 
 
 async def _main():
-    import argparse
+    import argparse  # noqa: PLC0415
 
     logging.basicConfig(
         format="%(asctime)s %(levelname)s: %(name)s: %(message)s", level=logging.DEBUG


### PR DESCRIPTION
With Python version 3.10 and older the asyncio.TimeoutError exception is
not the same as the builtin TimeoutError. That means the USB attach
timeout was treated like any error and the retry happened only after an
increasing delay.

Fixed by catching the deprecated asyncio.TimeoutError, which works for
all versions.