### PR TITLE
Drop support for Python < 3.10

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/not_my_board/_agent.py
+++ b/not_my_board/_agent.py
@@ -11,8 +11,8 @@ import socket
 import traceback
 import urllib.parse
 import weakref
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Mapping, Optional, Tuple
 
 import not_my_board._jsonrpc as jsonrpc
 import not_my_board._models as models
@@ -21,7 +21,7 @@ import not_my_board._util as util
 
 logger = logging.getLogger(__name__)
 USBIP_REMOTE = ("usb.not-my-board.localhost", 3240)
-Address = Tuple[str, int]
+Address = tuple[str, int]
 
 
 class AgentIO:
@@ -565,7 +565,7 @@ class _Reservation:
     place: models.Place
     is_attached: bool = field(default=False, init=False)
     tunnels: Mapping[_TunnelDesc, _Tunnel]
-    auto_return_task: Optional[asyncio.Task]
+    auto_return_task: asyncio.Task | None
 
 
 class ProtocolError(Exception):

--- a/not_my_board/_hub.py
+++ b/not_my_board/_hub.py
@@ -12,7 +12,6 @@ import os
 import pathlib
 import random
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Union
 
 import asgineer
 
@@ -466,7 +465,7 @@ class Authenticator(util.ContextStack):
 
 @dataclass
 class Permission:
-    claims: Dict[str, Union[dict, str, int, float, set, bool]]
+    claims: dict[str, dict | str | int | float | set | bool]
     roles: set
 
     @classmethod
@@ -483,7 +482,7 @@ class Permission:
 
 @dataclass
 class IssuerConfig:
-    show_claims: Optional[List[str]] = None
+    show_claims: list[str] | None = None
 
 
 def _unmap_ip(ip_str):

--- a/not_my_board/_jsonrpc/_protocol.py
+++ b/not_my_board/_jsonrpc/_protocol.py
@@ -9,7 +9,7 @@ import json
 import logging
 import textwrap
 import traceback
-from typing import Any, Optional, Union
+from typing import Any
 
 import not_my_board._util as util
 
@@ -229,7 +229,7 @@ def _parse_message(raw_data, info):
     data = json.loads(raw_data)
     id_ = data.get("id")
     if id_ is not None:
-        if not isinstance(id_, (str, int)):
+        if not isinstance(id_, str | int):
             raise ProtocolError('"id" must be a string or number')
         info["id"] = id_
 
@@ -242,7 +242,7 @@ def _parse_message(raw_data, info):
             raise ProtocolError('"method" must be a string')
 
         params = data.get("params", [])
-        if not isinstance(params, (list, dict)):
+        if not isinstance(params, list | dict):
             raise ProtocolError('"params" must be a structured value')
 
         return Request(id_, method, params)
@@ -276,7 +276,7 @@ def _parse_message(raw_data, info):
 @dataclasses.dataclass
 class _Message:
     jsonrpc: str = dataclasses.field(default="2.0", init=False)
-    id: Optional[Union[int, str]]
+    id: int | str | None
 
     def __bytes__(self):
         body = {}
@@ -293,7 +293,7 @@ class _Message:
 @dataclasses.dataclass
 class Request(_Message):
     method: str
-    params: Union[list, dict]
+    params: list | dict
 
     @property
     def args(self):

--- a/not_my_board/_models.py
+++ b/not_my_board/_models.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 import pydantic
 
 UsbId = pydantic.constr(regex=r"^[1-9][0-9]*-[1-9][0-9]*(\.[1-9][0-9]*)*$")
@@ -14,15 +12,15 @@ class TcpImportDesc(pydantic.BaseModel):
 
 
 class ImportedPart(pydantic.BaseModel):
-    compatible: List[str]
-    usb: Dict[str, UsbImportDesc] = {}
-    tcp: Dict[str, TcpImportDesc] = {}
+    compatible: list[str]
+    usb: dict[str, UsbImportDesc] = {}
+    tcp: dict[str, TcpImportDesc] = {}
 
 
 class ImportDesc(pydantic.BaseModel):
     name: str
     auto_return_time: str = "10h"
-    parts: Dict[str, ImportedPart]
+    parts: dict[str, ImportedPart]
 
 
 class UsbExportDesc(pydantic.BaseModel):
@@ -35,14 +33,14 @@ class TcpExportDesc(pydantic.BaseModel):
 
 
 class ExportedPart(pydantic.BaseModel):
-    compatible: List[str]
-    usb: Dict[str, UsbExportDesc] = {}
-    tcp: Dict[str, TcpExportDesc] = {}
+    compatible: list[str]
+    usb: dict[str, UsbExportDesc] = {}
+    tcp: dict[str, TcpExportDesc] = {}
 
 
 class ExportDesc(pydantic.BaseModel):
     port: pydantic.PositiveInt
-    parts: List[ExportedPart]
+    parts: list[ExportedPart]
 
 
 class Place(ExportDesc):

--- a/not_my_board/_usbip.py
+++ b/not_my_board/_usbip.py
@@ -9,15 +9,9 @@ import os
 import pathlib
 import socket
 import struct
-import sys
+from typing import Annotated
 
 import not_my_board._util as util
-
-if sys.version_info < (3, 9):
-    from typing_extensions import Annotated
-else:
-    from typing import Annotated
-
 
 logger = logging.getLogger(__name__)
 _vhci_status = {}
@@ -477,7 +471,7 @@ def serializable(cls):
         data = await reader.readexactly(cls._struct.size)
         values = cls._struct.unpack(data)
         init_values = []
-        for field, value in zip(dataclasses.fields(cls), values):
+        for field, value in zip(dataclasses.fields(cls), values, strict=True):
             if field.init:
                 if field.name in cls._to_strip:
                     value = value.rstrip(b"\0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 name = "not-my-board"
 description = "Tool to setup, manage and use a board farm "
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {file = "LICENSE.txt"}
 authors = [
     {name = "Simon Holesch", email = "simon@holesch.de"},
@@ -17,8 +17,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +33,6 @@ dependencies = [
     "pyjwt[crypto]",
     "tabulate",
     "tomli; python_version < '3.11'",
-    "typing_extensions; python_version < '3.9'",
     "uvicorn",
     "websockets",
 ]
@@ -151,11 +148,6 @@ ignore = [
     # "Use ternary operator instead of if-else-block"
     # -> can make the code less readable
     "SIM108",
-    # "Use a single with statement with multiple contexts instead of nested
-    #  with statements"
-    # -> only useful with Python version >= 3.10, when you can break the
-    #    statement into multiple lines
-    "SIM117",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,14 @@ def event_loop():
 async def vms():
     async with HubVM() as hub:
         await wait_for_ports(5001, 5002)
-        async with ExporterVM() as exporter:
-            async with ClientVM() as client:
-                await util.run_concurrently(
-                    hub.configure(),
-                    exporter.configure(),
-                    client.configure(),
-                )
-                await exporter.usb_attach()
-                yield VMs(hub, exporter, client)
+        async with (
+            ExporterVM() as exporter,
+            ClientVM() as client,
+        ):
+            await util.run_concurrently(
+                hub.configure(),
+                exporter.configure(),
+                client.configure(),
+            )
+            await exporter.usb_attach()
+            yield VMs(hub, exporter, client)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -189,9 +189,11 @@ class FakeAgentIO:
 @pytest.fixture
 async def agent_io():
     io = FakeAgentIO()
-    async with agentmodule.Agent(HUB_URL, io, None) as agent:
-        async with util.background_task(agent.serve_forever()):
-            yield io
+    async with (
+        agentmodule.Agent(HUB_URL, io, None) as agent,
+        util.background_task(agent.serve_forever()),
+    ):
+        yield io
 
 
 async def test_idle_list(agent_io):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -256,9 +256,11 @@ async def test_login_success(hub, http_client, token_store_path):
     fake_exporter = FakeExporter(rpc1, token_src, http_client)
     hub_coro = hub.communicate("3.1.1.1", rpc2)
     exporter_coro = fake_exporter.communicate_forever()
-    async with util.background_task(hub_coro):
-        async with util.background_task(exporter_coro):
-            await fake_exporter.register_place()
+    async with (
+        util.background_task(hub_coro),
+        util.background_task(exporter_coro),
+    ):
+        await fake_exporter.register_place()
 
 
 @pytest.mark.parametrize(
@@ -309,14 +311,16 @@ async def test_permissions(claims, is_allowed):
     fake_exporter = FakeExporter(rpc1, token_src, http_client_)
     hub_coro = hub_.communicate("3.1.1.1", rpc2)
     exporter_coro = fake_exporter.communicate_forever()
-    async with util.background_task(hub_coro):
-        async with util.background_task(exporter_coro):
-            try:
-                await fake_exporter.register_place()
-            except Exception:
-                assert not is_allowed
-            else:
-                assert is_allowed
+    async with (
+        util.background_task(hub_coro),
+        util.background_task(exporter_coro),
+    ):
+        try:
+            await fake_exporter.register_place()
+        except Exception:
+            assert not is_allowed
+        else:
+            assert is_allowed
 
 
 async def test_permission_lost(hub, http_client, token_store_path, fake_time):

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -64,10 +64,12 @@ async def register_exporter(hub, ip=DEFAULT_EXPORTER_IP):
     fake_exporter = FakeExporter(rpc1)
     hub_coro = hub.communicate(ip, rpc2)
     exporter_coro = fake_exporter.communicate_forever()
-    async with util.background_task(hub_coro) as hub_connection:
-        async with util.background_task(exporter_coro):
-            await fake_exporter.register_place()
-            yield fake_exporter, hub_connection
+    async with (
+        util.background_task(hub_coro) as hub_connection,
+        util.background_task(exporter_coro),
+    ):
+        await fake_exporter.register_place()
+        yield fake_exporter, hub_connection
 
 
 async def test_register_exporter(hub):
@@ -83,19 +85,23 @@ async def test_register_exporter(hub):
 async def register_agent(hub, ip=DEFAULT_AGENT_IP):
     rpc1, rpc2 = fake_rpc_pair()
     coro = hub.communicate(ip, rpc2)
-    async with util.background_task(coro):
-        async with util.background_task(rpc1.communicate_forever()):
-            yield rpc1
+    async with (
+        util.background_task(coro),
+        util.background_task(rpc1.communicate_forever()),
+    ):
+        yield rpc1
 
 
 async def test_reserve_place(hub):
-    async with register_exporter(hub) as (exporter, _):
-        async with register_agent(hub) as agent:
-            places = await hub.get_places()
-            candidate_ids = [places["places"][0]["id"]]
-            reserved_id = await agent.reserve(candidate_ids)
-            assert reserved_id == candidate_ids[0]
-            assert exporter.allowed_ips == [DEFAULT_AGENT_IP]
+    async with (
+        register_exporter(hub) as (exporter, _),
+        register_agent(hub) as agent,
+    ):
+        places = await hub.get_places()
+        candidate_ids = [places["places"][0]["id"]]
+        reserved_id = await agent.reserve(candidate_ids)
+        assert reserved_id == candidate_ids[0]
+        assert exporter.allowed_ips == [DEFAULT_AGENT_IP]
 
 
 async def test_reserve_non_existent(hub):
@@ -107,89 +113,97 @@ async def test_reserve_non_existent(hub):
 
 
 async def test_reserve_queue(hub):
-    async with register_exporter(hub):
-        async with register_agent(hub) as agent:
-            places = await hub.get_places()
-            candidate_ids = [places["places"][0]["id"]]
-            reserved_id = await agent.reserve(candidate_ids)
+    async with (
+        register_exporter(hub),
+        register_agent(hub) as agent,
+    ):
+        places = await hub.get_places()
+        candidate_ids = [places["places"][0]["id"]]
+        reserved_id = await agent.reserve(candidate_ids)
 
-            # try to reserve same place again
-            coro = agent.reserve(candidate_ids)
-            async with util.background_task(coro) as reserve_task:
-                await asyncio.sleep(0.001)
-                # request should be in queue now
-                assert not reserve_task.done()
+        # try to reserve same place again
+        coro = agent.reserve(candidate_ids)
+        async with util.background_task(coro) as reserve_task:
+            await asyncio.sleep(0.001)
+            # request should be in queue now
+            assert not reserve_task.done()
 
-                # when the first reservation is returned ...
-                await agent.return_reservation(reserved_id)
-                # ... then the second one can be fulfilled
-                assert await reserve_task == reserved_id
+            # when the first reservation is returned ...
+            await agent.return_reservation(reserved_id)
+            # ... then the second one can be fulfilled
+            assert await reserve_task == reserved_id
 
 
 async def test_all_places_disappear_while_trying_to_reserve(hub):
-    async with register_exporter(hub) as (_, exporter_task):
-        async with register_agent(hub) as agent:
-            places = await hub.get_places()
-            candidate_ids = [places["places"][0]["id"]]
-            await agent.reserve(candidate_ids)
+    async with (
+        register_exporter(hub) as (_, exporter_task),
+        register_agent(hub) as agent,
+    ):
+        places = await hub.get_places()
+        candidate_ids = [places["places"][0]["id"]]
+        await agent.reserve(candidate_ids)
 
-            with pytest.raises(jsonrpc.RemoteError) as execinfo:
-                # try to reserve same place again
-                coro = agent.reserve(candidate_ids)
-                async with util.background_task(coro):
-                    await asyncio.sleep(0.001)
-                    # request should be in queue now
+        with pytest.raises(jsonrpc.RemoteError) as execinfo:
+            # try to reserve same place again
+            coro = agent.reserve(candidate_ids)
+            async with util.background_task(coro):
+                await asyncio.sleep(0.001)
+                # request should be in queue now
 
-                    # when the exporter disappears ...
-                    await util.cancel_tasks([exporter_task])
-                    await asyncio.sleep(0.5)
-            # ... then the queued reservation is canceled
-            assert "All candidate places are gone" in str(execinfo.value)
+                # when the exporter disappears ...
+                await util.cancel_tasks([exporter_task])
+                await asyncio.sleep(0.5)
+        # ... then the queued reservation is canceled
+        assert "All candidate places are gone" in str(execinfo.value)
 
 
 async def test_one_place_disappears_while_trying_to_reserve(hub):
-    async with register_exporter(hub):
-        async with register_exporter(hub) as (_, exporter_task):
-            async with register_agent(hub) as agent:
-                places = await hub.get_places()
-                # reserve both places
-                candidate_ids = [p["id"] for p in places["places"]]
-                await agent.reserve(candidate_ids)
-                await agent.reserve(candidate_ids)
+    async with (
+        register_exporter(hub),
+        register_exporter(hub) as (_, exporter_task),
+        register_agent(hub) as agent,
+    ):
+        places = await hub.get_places()
+        # reserve both places
+        candidate_ids = [p["id"] for p in places["places"]]
+        await agent.reserve(candidate_ids)
+        await agent.reserve(candidate_ids)
 
-                # try to reserve both places again
-                coro = agent.reserve(candidate_ids)
-                async with util.background_task(coro) as reserve_task:
-                    await asyncio.sleep(0.001)
-                    # request should be in queue now
-                    assert not reserve_task.done()
+        # try to reserve both places again
+        coro = agent.reserve(candidate_ids)
+        async with util.background_task(coro) as reserve_task:
+            await asyncio.sleep(0.001)
+            # request should be in queue now
+            assert not reserve_task.done()
 
-                    # when one exporter disappears ...
-                    await util.cancel_tasks([exporter_task])
-                    # ... then the queued reservation is still active
-                    assert not reserve_task.done()
+            # when one exporter disappears ...
+            await util.cancel_tasks([exporter_task])
+            # ... then the queued reservation is still active
+            assert not reserve_task.done()
 
 
 async def test_return_non_candidate(hub):
-    async with register_exporter(hub):
-        async with register_exporter(hub):
-            async with register_agent(hub) as agent:
-                places = await hub.get_places()
-                # reserve both places
-                candidate_ids = [p["id"] for p in places["places"]]
-                await agent.reserve(candidate_ids)
-                await agent.reserve(candidate_ids)
+    async with (
+        register_exporter(hub),
+        register_exporter(hub),
+        register_agent(hub) as agent,
+    ):
+        places = await hub.get_places()
+        # reserve both places
+        candidate_ids = [p["id"] for p in places["places"]]
+        await agent.reserve(candidate_ids)
+        await agent.reserve(candidate_ids)
 
-                # try to reserve place #1 again
-                coro = agent.reserve(candidate_ids[:1])
-                async with util.background_task(coro) as reserve_task:
-                    await asyncio.sleep(0.001)
-                    # request should be in queue now
+        # try to reserve place #1 again
+        coro = agent.reserve(candidate_ids[:1])
+        async with util.background_task(coro) as reserve_task:
+            await asyncio.sleep(0.001)
+            # request should be in queue now
 
-                    # when place #2 is returned ...
-                    await agent.return_reservation(candidate_ids[1])
-                    # ... then the queued reservation is still active
-                    assert not reserve_task.done()
+            # when place #2 is returned ...
+            await agent.return_reservation(candidate_ids[1])
+            # ... then the queued reservation is still active
+            assert not reserve_task.done()
 
 
 async def test_mapped_ip_exporter(hub):
@@ -199,9 +213,11 @@ async def test_mapped_ip_exporter(hub):
 
 
 async def test_mapped_ip_agent(hub):
-    async with register_exporter(hub) as (exporter, _):
-        async with register_agent(hub, ip="::FFFF:10.0.0.9") as agent:
-            places = await hub.get_places()
-            candidate_ids = [places["places"][0]["id"]]
-            await agent.reserve(candidate_ids)
-            assert exporter.allowed_ips == ["10.0.0.9"]
+    async with (
+        register_exporter(hub) as (exporter, _),
+        register_agent(hub, ip="::FFFF:10.0.0.9") as agent,
+    ):
+        places = await hub.get_places()
+        candidate_ids = [places["places"][0]["id"]]
+        await agent.reserve(candidate_ids)
+        assert exporter.allowed_ips == ["10.0.0.9"]

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,23 +1,25 @@
 async def test_tutorial(vms):
-    async with vms.hub.ssh_task("not-my-board hub", "hub", wait_ready=True):
-        async with vms.hub.ssh_task(
+    async with (
+        vms.hub.ssh_task("not-my-board hub", "hub", wait_ready=True),
+        vms.hub.ssh_task(
             "python3 -m http.server -d ./src/tests/tutorial -b localhost 8080",
             "http_server",
-        ):
-            async with vms.hub.ssh_task(
-                "not-my-board export http://localhost:2092 ./src/tests/tutorial/tutorial-tcp-place.toml",
-                "export",
-                wait_ready=True,
-            ):
-                async with vms.hub.ssh_task_root(
-                    "not-my-board agent http://localhost:2092", "agent", wait_ready=True
-                ):
-                    await vms.hub.ssh(
-                        "doas not-my-board attach ./src/tests/tutorial/tutorial-tcp.toml"
-                    )
+        ),
+        vms.hub.ssh_task(
+            "not-my-board export http://localhost:2092 ./src/tests/tutorial/tutorial-tcp-place.toml",
+            "export",
+            wait_ready=True,
+        ),
+        vms.hub.ssh_task_root(
+            "not-my-board agent http://localhost:2092", "agent", wait_ready=True
+        ),
+    ):
+        await vms.hub.ssh(
+            "doas not-my-board attach ./src/tests/tutorial/tutorial-tcp.toml"
+        )
 
-                    await vms.hub.ssh_poll("nc -z localhost 8080")
-                    result = await vms.hub.ssh(
-                        "wget -qO - http://localhost:8081/hello", prefix="wget"
-                    )
-                    assert result.stdout.rstrip() == "Hello, World!"
+        await vms.hub.ssh_poll("nc -z localhost 8080")
+        result = await vms.hub.ssh(
+            "wget -qO - http://localhost:8081/hello", prefix="wget"
+        )
+        assert result.stdout.rstrip() == "Hello, World!"

--- a/tests/test_usbip.py
+++ b/tests/test_usbip.py
@@ -2,80 +2,84 @@ import pathlib
 
 
 async def test_raw_usb_forwarding(vms):
-    async with vms.exporter.ssh_task_root(
-        "python3 -m not_my_board._usbip export 2-1", "usbip export", wait_ready=True
-    ):
-        async with vms.client.ssh_task_root(
+    async with (
+        vms.exporter.ssh_task_root(
+            "python3 -m not_my_board._usbip export 2-1", "usbip export", wait_ready=True
+        ),
+        vms.client.ssh_task_root(
             "python3 -m not_my_board._usbip import exporter.local 2-1 0",
             "usbip import",
-        ):
-            # wait for USB device to appear
-            await vms.client.ssh_poll("test -e /dev/usbdisk")
+        ),
+    ):
+        # wait for USB device to appear
+        await vms.client.ssh_poll("test -e /dev/usbdisk")
 
-            await vms.client.ssh("doas mount /media/usb")
-            try:
-                result = await vms.client.ssh("cat /media/usb/hello")
-                assert result.stdout == "Hello, World!"
-            finally:
-                await vms.client.ssh("doas umount /media/usb")
+        await vms.client.ssh("doas mount /media/usb")
+        try:
+            result = await vms.client.ssh("cat /media/usb/hello")
+            assert result.stdout == "Hello, World!"
+        finally:
+            await vms.client.ssh("doas umount /media/usb")
 
     await vms.client.ssh_poll("! test -e /sys/bus/usb/devices/2-1")
 
 
 async def test_usb_forwarding(vms):
-    async with vms.hub.ssh_task("not-my-board hub", "hub", wait_ready=True):
-        async with vms.exporter.ssh_task_root(
+    async with (
+        vms.hub.ssh_task("not-my-board hub", "hub", wait_ready=True),
+        vms.exporter.ssh_task_root(
             "not-my-board export http://hub.local:2092 ./src/tests/qemu-usb-place.toml",
             "export",
             wait_ready=True,
-        ):
-            async with vms.client.ssh_task_root(
-                "not-my-board agent http://hub.local:2092", "agent", wait_ready=True
-            ):
-                await vms.client.ssh("not-my-board attach ./src/tests/qemu-usb.toml")
-                # TODO attach still returns before the device is available.
-                # would be nice if it blocks until the device is ready.
-                await vms.client.ssh_poll("test -e /sys/bus/usb/devices/2-1")
+        ),
+        vms.client.ssh_task_root(
+            "not-my-board agent http://hub.local:2092", "agent", wait_ready=True
+        ),
+    ):
+        await vms.client.ssh("not-my-board attach ./src/tests/qemu-usb.toml")
+        # TODO attach still returns before the device is available.
+        # would be nice if it blocks until the device is ready.
+        await vms.client.ssh_poll("test -e /sys/bus/usb/devices/2-1")
 
-                result = await vms.client.ssh("not-my-board status")
-                status_str = result.stdout.rstrip()
-                status_lines = status_str.split("\n")
-                assert len(status_lines) == 2
-                header = status_lines[0].split()
-                status_line = status_lines[1].split()
+        result = await vms.client.ssh("not-my-board status")
+        status_str = result.stdout.rstrip()
+        status_lines = status_str.split("\n")
+        assert len(status_lines) == 2
+        header = status_lines[0].split()
+        status_line = status_lines[1].split()
 
-                assert header == [
-                    "Place",
-                    "Part",
-                    "Type",
-                    "Interface",
-                    "Status",
-                    "Port",
-                ]
-                assert status_line == [
-                    "qemu-usb",
-                    "flash-drive",
-                    "USB",
-                    "usb0",
-                    "Up",
-                    "2-1",
-                ]
+        assert header == [
+            "Place",
+            "Part",
+            "Type",
+            "Interface",
+            "Status",
+            "Port",
+        ]
+        assert status_line == [
+            "qemu-usb",
+            "flash-drive",
+            "USB",
+            "usb0",
+            "Up",
+            "2-1",
+        ]
 
-                try:
-                    await vms.exporter.usb_detach()
-                    await vms.client.ssh_poll("! test -e /sys/bus/usb/devices/2-1")
-                finally:
-                    await vms.exporter.usb_attach()
+        try:
+            await vms.exporter.usb_detach()
+            await vms.client.ssh_poll("! test -e /sys/bus/usb/devices/2-1")
+        finally:
+            await vms.exporter.usb_attach()
 
-                await vms.client.ssh_poll("test -e /sys/bus/usb/devices/2-1")
-                await vms.client.ssh("not-my-board detach -k qemu-usb")
-                await vms.client.ssh("! test -e /sys/bus/usb/devices/2-1")
+        await vms.client.ssh_poll("test -e /sys/bus/usb/devices/2-1")
+        await vms.client.ssh("not-my-board detach -k qemu-usb")
+        await vms.client.ssh("! test -e /sys/bus/usb/devices/2-1")
 
-                result = await vms.client.ssh("not-my-board status")
-                status_str = result.stdout.rstrip()
-                status_lines = status_str.split("\n")
-                status_line = status_lines[1].split()
-                assert status_line[5] == "1-1/2-1"
+        result = await vms.client.ssh("not-my-board status")
+        status_str = result.stdout.rstrip()
+        status_lines = status_str.split("\n")
+        status_line = status_lines[1].split()
+        assert status_line[5] == "1-1/2-1"
 
     # When the exporter is killed, then it should clean up and restore the
     # default USB driver.


### PR DESCRIPTION
Ubuntu 20.04 LTS reached end of standard support, allowing us to drop Python 3.8 and 3.9 support. This modernizes the codebase to use Python 3.10+ features and simplifies maintenance by reducing compatibility burden.