### PR TITLE
Fix edit command for old python versions

### DIFF
--- a/not_my_board/_util/_logging.py
+++ b/not_my_board/_util/_logging.py
@@ -17,8 +17,8 @@ _request_id = contextvars.ContextVar("request_id")
 
 def configure_logging(level):
     # reduce level of verbose loggers
-    logging.getLogger("websockets.client").setLevel(logging.INFO)
-    logging.getLogger("asyncio").setLevel(logging.INFO)
+    logging.getLogger("websockets.client").setLevel(max(level, logging.INFO))
+    logging.getLogger("asyncio").setLevel(max(level, logging.INFO))
 
     root = logging.getLogger()
     root.setLevel(level)

--- a/tests/fake_editor.sh
+++ b/tests/fake_editor.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+exec sed -i 's/port_num = 0/port_num = 1/' "$@"


### PR DESCRIPTION
The delete_on_close parameter was only added in Python version 3.12.
Update the tempfile handling to use delete=False and remove the file
manually.