### PR TITLE
CLI: Sort search output

### DIFF
--- a/not_my_board/cli/__init__.py
+++ b/not_my_board/cli/__init__.py
@@ -299,8 +299,9 @@ async def _edit_command(args):
 
 async def _search_command(args):
     result = await client.search(args.import_description)
-    for entry in result:
-        print(f"@{entry['name']}")
+    names = [entry["name"] for entry in result]
+    for name in sorted(names):
+        print(f"@{name}")
 
 
 async def _show_command(args):

--- a/tests/system_test/abc-place.toml
+++ b/tests/system_test/abc-place.toml
@@ -1,0 +1,4 @@
+port = 2303
+
+[[parts]]
+compatible = [ "nothing" ]

--- a/tests/system_test/xyz-place.toml
+++ b/tests/system_test/xyz-place.toml
@@ -1,0 +1,4 @@
+port = 2304
+
+[[parts]]
+compatible = [ "nothing" ]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -66,6 +66,24 @@ async def test_search_all(farm):
     assert "@place3" in place_names
 
 
+async def test_search_is_sorted(farm):
+    async with (
+        farm.exporter.ssh_task(
+            "not-my-board export http://hub.local:2092 ./src/tests/system_test/abc-place.toml",
+            "export-abc",
+            wait_ready=True,
+        ),
+        farm.exporter.ssh_task(
+            "not-my-board export http://hub.local:2092 ./src/tests/system_test/xyz-place.toml",
+            "export-xyz",
+            wait_ready=True,
+        ),
+    ):
+        result = await farm.client.ssh("not-my-board search")
+        place_names = result.stdout.split("\n")
+        assert place_names == sorted(place_names)
+
+
 async def test_search(farm):
     result = await farm.client.ssh(
         "not-my-board search ./src/tests/system_test/nothing.toml"


### PR DESCRIPTION
If the Hub restarts, then the order in which the exporters are registered is kind of random. Most likely the registration order is not interesting, so sort the output alphabetically, because sorted lists are easier to compare with each other and it's easier to spot missing names.